### PR TITLE
Add bench-run support in profiles

### DIFF
--- a/bin/common
+++ b/bin/common
@@ -6,7 +6,7 @@ trim() {
 
 measure-and-output() {
   cd "$PROG_HOME/dotty"
-  sbt "$@" 2>&1 | tee output.txt
+  sbt "$1" 2>&1 | tee output.txt
 
   if [ $? -eq 0 ]; then
     runs=$(cat output.txt | grep -E '^Iteration' | sed -r 's/^Iteration.*: ([0-9\.]+).*$/\1/')
@@ -28,11 +28,13 @@ Please check the log file for more details: $LOG_URL/$(basename $LOG)"
 }
 
 measure() {
-  measure-and-output "dotty-bench-bootstrapped/jmh:run $@ -d $PROG_HOME/out -nowarn"
+  args="$@"
+  measure-and-output "dotty-bench-bootstrapped/jmh:run $args -d $PROG_HOME/out -nowarn"
 }
 
 measure-run() {
-  measure-and-output "dotty-bench-run/jmh:run $@"
+  args="$@"
+  measure-and-output "dotty-bench-run/jmh:run $args"
 }
 
 prepare() {

--- a/bin/common
+++ b/bin/common
@@ -4,9 +4,13 @@ trim() {
   echo -e "$1" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
 }
 
-measure-and-output() {
+run-sbt() {
   cd "$PROG_HOME/dotty"
-  sbt "$1" 2>&1 | tee output.txt
+  sbt "$1"
+}
+
+measure-and-output() {
+  run-sbt "$1" 2>&1 | tee output.txt
 
   if [ $? -eq 0 ]; then
     runs=$(cat output.txt | grep -E '^Iteration' | sed -r 's/^Iteration.*: ([0-9\.]+).*$/\1/')

--- a/bin/common
+++ b/bin/common
@@ -5,6 +5,8 @@ trim() {
 }
 
 jmh() {
+  command="$1"
+  shift
   args="$@"
 
   cd "$PROG_HOME/dotty"
@@ -12,7 +14,7 @@ jmh() {
   sbt "dotty-bench-bootstrapped/jmh:run $args -d $PROG_HOME/out -nowarn"
 }
 
-measure() {
+measure-jmh() {
   jmh "$@" 2>&1 | tee output.txt
 
   if [ $? -eq 0 ]; then
@@ -34,26 +36,12 @@ Please check the log file for more details: $LOG_URL/$(basename $LOG)"
   fi
 }
 
+measure() {
+  measure-jmh "dotty-bench-bootstrapped/jmh:run $@"
+}
+
 measure-run() {
-  cd "$PROG_HOME/dotty"
-  sbt "dotty-bench-run/jmh:run $@" 2>&1 | tee output.txt
-
-  if [ $? -eq 0 ]; then
-    runs=$(cat output.txt | grep -E '^Iteration' | sed -r 's/^Iteration.*: ([0-9\.]+).*$/\1/')
-    warmups=$(cat output.txt | grep -E '^# Warmup Iteration' | sed -r 's/^# Warmup Iteration.*: ([0-9\.]+).*$/\1/' | tr '\n' ' ')
-
-    runs_flat=$(echo "$runs" | tr '\n' ' ')
-    runs_flat=$(trim "$runs_flat")
-
-    if [ -z "$runs_flat" ]; then
-      log_url="$LOG_URL/$(basename $LOG)"
-      message="test $key failed for $pr
-
-Please check the log file for more details: $LOG_URL/$(basename $LOG)"
-    else
-      echo "$key, $pr, $time, $commit, $(date), $warmups, $runs_flat" >> "$FILE"
-    fi
-  fi
+  measure-jmh "dotty-bench-run/jmh:run $@"
 }
 
 prepare() {

--- a/bin/common
+++ b/bin/common
@@ -34,6 +34,28 @@ Please check the log file for more details: $LOG_URL/$(basename $LOG)"
   fi
 }
 
+measure-run() {
+  cd "$PROG_HOME/dotty"
+  sbt "dotty-bench-run/jmh:run $@" 2>&1 | tee output.txt
+
+  if [ $? -eq 0 ]; then
+    runs=$(cat output.txt | grep -E '^Iteration' | sed -r 's/^Iteration.*: ([0-9\.]+).*$/\1/')
+    warmups=$(cat output.txt | grep -E '^# Warmup Iteration' | sed -r 's/^# Warmup Iteration.*: ([0-9\.]+).*$/\1/' | tr '\n' ' ')
+
+    runs_flat=$(echo "$runs" | tr '\n' ' ')
+    runs_flat=$(trim "$runs_flat")
+
+    if [ -z "$runs_flat" ]; then
+      log_url="$LOG_URL/$(basename $LOG)"
+      message="test $key failed for $pr
+
+Please check the log file for more details: $LOG_URL/$(basename $LOG)"
+    else
+      echo "$key, $pr, $time, $commit, $(date), $warmups, $runs_flat" >> "$FILE"
+    fi
+  fi
+}
+
 prepare() {
   commit=$1
 

--- a/bin/common
+++ b/bin/common
@@ -38,7 +38,7 @@ measure() {
 
 measure-run() {
   args="$@"
-  measure-and-output "dotty-bench-run/jmh:run $args"
+  measure-and-output "dotty-bench-run/jmh:run $args -- $PROG_HOME/out"
 }
 
 prepare() {

--- a/bin/common
+++ b/bin/common
@@ -4,18 +4,9 @@ trim() {
   echo -e "$1" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
 }
 
-jmh() {
-  command="$1"
-  shift
-  args="$@"
-
+measure-and-output() {
   cd "$PROG_HOME/dotty"
-
-  sbt "dotty-bench-bootstrapped/jmh:run $args -d $PROG_HOME/out -nowarn"
-}
-
-measure-jmh() {
-  jmh "$@" 2>&1 | tee output.txt
+  sbt "$@" 2>&1 | tee output.txt
 
   if [ $? -eq 0 ]; then
     runs=$(cat output.txt | grep -E '^Iteration' | sed -r 's/^Iteration.*: ([0-9\.]+).*$/\1/')
@@ -37,11 +28,11 @@ Please check the log file for more details: $LOG_URL/$(basename $LOG)"
 }
 
 measure() {
-  measure-jmh "dotty-bench-bootstrapped/jmh:run $@"
+  measure-and-output "dotty-bench-bootstrapped/jmh:run $@ -d $PROG_HOME/out -nowarn"
 }
 
 measure-run() {
-  measure-jmh "dotty-bench-run/jmh:run $@"
+  measure-and-output "dotty-bench-run/jmh:run $@"
 }
 
 prepare() {

--- a/profiles/tuple-runtime.js
+++ b/profiles/tuple-runtime.js
@@ -1,0 +1,5 @@
+var Bench = Bench || {}
+Bench.charts = [
+{"name":"Tuple reverse","lines":[{"key":"tuple-reverse","label":"bootstrapped"}]},
+{"name":"Tuple flatMap","lines":[{"key":"tuple-flatMap","label":"bootstrapped"}]}
+]

--- a/profiles/tuple-runtime.plan
+++ b/profiles/tuple-runtime.plan
@@ -1,0 +1,8 @@
+set -e
+
+set-key tuple-reverse
+measure-run TupleOps.reverse
+
+set-key tuple-flatMap
+measure-run TupleOps.flatMap
+

--- a/profiles/tuple-runtime.yml
+++ b/profiles/tuple-runtime.yml
@@ -1,0 +1,17 @@
+charts:
+    - name: "Tuple reverse"
+      lines:
+        - key: tuple-reverse
+          label: bootstrapped
+
+    - name: "Tuple flatMap"
+      lines:
+        - key: tuple-flatMap
+          label: bootstrapped
+
+scripts:
+    tuple-reverse:
+        - measure-run TupleOps.reverse
+
+    tuple-flatMap:
+        - measure-run TupleOps.flatMap


### PR DESCRIPTION
This pull requests builds on pull request #7596 from dotty. It allows runtime benchmarks from the `bench-run` project to be launched from the profile files.
We could use that later in the future to monitor how the performance of certain parts of the standard library evolve over time.
Right now, I added a profile for tuple benchmarks since this is what I am currently trying to improve, but it could be used to launch some other benchmarks.
See @liufengyun and @nicolasstucki for more info.