### PR TITLE
Fix macros after syntax change

### DIFF
--- a/tests/power-macro/PowerMacro.scala
+++ b/tests/power-macro/PowerMacro.scala
@@ -2,9 +2,12 @@ import scala.quoted._
 
 object PowerMacro {
 
-  inline def power(inline n: Long, x: Double) = ${ powerCode(n, 'x) }
+  inline def power(inline n: Long, x: Double) = ${ powerCode('n, 'x) }
 
-  def powerCode(n: Long, x: Expr[Double])(given QuoteContext): Expr[Double] =
+  def powerCode(n: Expr[Long], x: Expr[Double])(using QuoteContext): Expr[Double] =
+    powerCode(n.value, x)
+
+  def powerCode(n: Long, x: Expr[Double])(using QuoteContext): Expr[Double] =
     if (n == 0) '{1.0}
     else if (n % 2 == 0) '{ val y = $x * $x; ${powerCode(n / 2, 'y)} }
     else '{ $x * ${powerCode(n - 1, x)} }


### PR DESCRIPTION
Fix macros after syntax change