### PR TITLE
Fix #79: only test performance for PR from dotty-staging

### DIFF
--- a/bin/common
+++ b/bin/common
@@ -38,7 +38,7 @@ measure() {
 
 measure-run() {
   args="$@"
-  measure-and-output "dotty-bench-run/jmh:run $args -- $PROG_HOME/out"
+  measure-and-output "dotty-bench-run/jmh:run $args --"
 }
 
 prepare() {

--- a/bin/master
+++ b/bin/master
@@ -61,7 +61,7 @@ do
   author=$(echo $commit_line | cut -d',' -f2)
   time=$(echo $commit_line | cut -d',' -f3)
 
-  if [[ $commit_line == *"Merge pull request #"* ]]; then
+  if [[ $commit_line == *"Merge pull request #"* ]] && [[ $commit_line == *"from dotty-staging"* ]]; then
     pr=$(echo $commit_line | cut -d',' -f4 | grep -o 'pull request #[0-9]\+' | grep -o '[0-9]\+')
 
     # 1. avoiding rescheduling of same commit


### PR DESCRIPTION
Fix #79: only test performance for PR from dotty-staging

Otherwise, we run the risk of testing meaningless commits,
and feed incorrect data into the database.

Note that this only skip testing the PRs that are merged into master. Testing for open PRs always work.