### PR TITLE
Fix #92: update compiler option to -source 3.0-migration

### DIFF
--- a/tests/scripts/scalap
+++ b/tests/scripts/scalap
@@ -2,4 +2,4 @@ set -e
 
 path=$($PROG_HOME/bin/coursier fetch -p org.scala-lang:scala-compiler:2.13.0)
 
-measure -language:Scala2Compat -classpath "$path" $(find $PROG_HOME/dotty/community-build/community-projects/scalap/src/scalap -name "*.scala")
+measure -source 3.0-migration -classpath "$path" $(find $PROG_HOME/dotty/community-build/community-projects/scalap/src/scalap -name "*.scala")


### PR DESCRIPTION
Fix #92: update compiler option to -source 3.0-migration

Related PR: https://github.com/lampepfl/dotty/pull/8700