### PR TITLE
Fix #190: Use run-sbt for compiling macros

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,6 @@ branches:
     - master
     - develop
 script:
+  - set -e
   - bin/ci
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ branches:
     - master
     - develop
 script:
+  - echo "CI=true" >> bin/config
   - curl -Lo bin/coursier https://git.io/coursier-cli && chmod +x bin/coursier && bin/coursier --help
   - git clone --recursive --single-branch https://github.com/lampepfl/dotty.git
   - echo "hello, world" > /dev/stdout

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,5 @@ branches:
     - master
     - develop
 script:
-  - echo "CI=true" >> bin/config
-  - curl -Lo bin/coursier https://git.io/coursier-cli && chmod +x bin/coursier && bin/coursier --help
-  - git clone --recursive --single-branch https://github.com/lampepfl/dotty.git
-  - echo "hello, world" > /dev/stdout
-  - bin/sync-profiles
-  - bin/process -t fixture/comments.txt lampepfl/dotty fixture/comments.json
-  - bin/gauge -o data.csv -p profiles/ci.plan 9999 master
-  - cat data.csv
-  - mkdir data && bin/csv -p profiles/fast.yml data.csv data/
+  - bin/ci
+

--- a/bin/ci
+++ b/bin/ci
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "CI=true" >> bin/config
+curl -Lo bin/coursier https://git.io/coursier-cli && chmod +x bin/coursier && bin/coursier --help
+git clone --recursive --single-branch https://github.com/lampepfl/dotty.git
+echo "hello, world" > /dev/stdout
+bin/sync-profiles
+bin/process -t fixture/comments.txt lampepfl/dotty fixture/comments.json
+bin/gauge -o data.csv -p profiles/ci.plan 9999 master
+cat data.csv
+mkdir data && bin/csv -p profiles/fast.yml data.csv data/

--- a/bin/common
+++ b/bin/common
@@ -22,7 +22,7 @@ measure-and-output() {
     runs_flat=$(trim "$runs_flat")
 
     if [ -z "$runs_flat" ]; then
-      if [ -z ${CI+x} ]; then
+      if [ -z "$CI" ]; then
         log_url="$LOG_URL/$(basename $LOG)"
         message="test $key failed for $pr
 
@@ -69,7 +69,8 @@ prepare() {
 }
 
 compile() {
-  run-sbt "dotty-bootstrapped/dotc" "$@" 2>&1 | tee -a "$LOG"
+  args="$@"
+  run-sbt "dotty-bootstrapped/dotc $args" 2>&1 | tee -a "$LOG"
 }
 
 set-key() {

--- a/bin/common
+++ b/bin/common
@@ -65,7 +65,7 @@ prepare() {
 }
 
 compile() {
-  "$PROG_HOME/dotty/bin/dotc" "$@" 2>&1 | tee -a "$LOG"
+  run-sbt "dotty-bootstrapped/dotc" "$@" 2>&1 | tee -a "$LOG"
 }
 
 set-key() {

--- a/bin/common
+++ b/bin/common
@@ -22,11 +22,15 @@ measure-and-output() {
     runs_flat=$(trim "$runs_flat")
 
     if [ -z "$runs_flat" ]; then
-      log_url="$LOG_URL/$(basename $LOG)"
-      message="test $key failed for $pr
+      if [ -z ${CI+x} ]; then
+        log_url="$LOG_URL/$(basename $LOG)"
+        message="test $key failed for $pr
 
 Please check the log file for more details: $LOG_URL/$(basename $LOG)"
-      ghi open -m "$message" -- $MONITOR_REPO
+        ghi open -m "$message" -- $MONITOR_REPO
+      else # CI is set
+        exit 1
+      fi
     else
       echo "$key, $pr, $time, $commit, $(date), $warmups, $runs_flat" >> "$FILE"
     fi


### PR DESCRIPTION
Fix #190: Use run-sbt for compiling macros