### PR TITLE
Fix precompile

### DIFF
--- a/bin/common
+++ b/bin/common
@@ -65,7 +65,7 @@ prepare() {
   run-sbt "dotty-bench-bootstrapped/jmh:compile" 2>&1 | tee -a "$LOG"
 
   # for compilation with `dotc`
-  run-sbt "dist-bootstrapped/pack"  2>&1 | tee -a "$LOG"
+  run-sbt "dist/pack"  2>&1 | tee -a "$LOG"
 }
 
 compile() {

--- a/bin/common
+++ b/bin/common
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 trim() {
   echo -e "$1" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
 }


### PR DESCRIPTION
This problem is caused by a recent change in Dotty:

lampepfl/dotty#8916

Luckily, it does not impact the test result.
Only the PowerMacro tests use `compile` to
precompile code, and precompiling is not part
of the benchmarks.
