### PR TITLE
Fix #211: avoid wget which touches temp file

### DIFF
--- a/bin/poll
+++ b/bin/poll
@@ -55,8 +55,10 @@ TEMP_FILE="$PROG_HOME/last-message.json"
 
 ############## Polling
 while true; do
-  wget https://api.github.com/repos/$REPO/issues/comments?since=$LAST_POLL -O "$TEMP_FILE"
+  curl "https://api.github.com/repos/$REPO/issues/comments?since=$LAST_POLL" > "$TEMP_FILE"
   LAST_POLL=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+  cat "$TEMP_FILE"
 
   bin/process $REPO "$TEMP_FILE"
 

--- a/bin/pull
+++ b/bin/pull
@@ -138,7 +138,7 @@ mkdir -p $SESSION_HOME
 ############# get PR info
 
 output=/tmp/pull-$PR
-wget https://api.github.com/repos/lampepfl/dotty/pulls/$PR -O $output
+curl "https://api.github.com/repos/lampepfl/dotty/pulls/$PR" > $output
 
 info=$(cat $output | jq '{ commit: .head.sha, author: .user.login, repo: .head.repo.full_name, branch: .head.ref }')
 author=$(echo $info | jq -r '.author' )


### PR DESCRIPTION
Fix #211: avoid wget which touches temp file

Bot not responsive sometimes, as noticed in https://github.com/lampepfl/dotty/pull/8935 and https://github.com/lampepfl/dotty/pull/9053

This is a follow up of https://github.com/lampepfl/bench/pull/170, where the network file system creates instability.
From manual testing on the server, `wget` relies on temp files,
which takes more than 1min to save the file and the content
of the file is incorrect.

Using of `curl` avoids the problem.