### PR TITLE
Re-enable volatile.scala in compiling stdlib

### DIFF
--- a/tests/scripts/stdlib213
+++ b/tests/scripts/stdlib213
@@ -1,7 +1,7 @@
 set -e
 
-pattern="! -name AnyVal.scala ! -name language.scala ! -name volatile.scala -name *.scala -o -name *.java"
+pattern="! -name AnyVal.scala ! -name language.scala -name *.scala -o -name *.java"
 stdlib213=$(find $PROG_HOME/dotty/community-build/community-projects/stdLib213/src/library/scala $pattern)
 cd $PROG_HOME/dotty
-sbt "dotty-bootstrapped/dotc -language:implicitConversions $stdlib213"
+measure -language:implicitConversions $stdlib213
 


### PR DESCRIPTION
It depends on the following fix:

https://github.com/lampepfl/dotty/pull/9433