### PR TITLE
Fix regression scheduler

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -88,7 +88,7 @@ cd "$PROG_HOME/dotty"
 git fetch origin master
 
 # c488e01 is the commit that refactors the repo
-merge_commits=$(git log --merges --pretty=format:'%h,%an,%ad,%s' c488e01..HEAD --reverse)
+merge_commits=$(git log --merges --pretty=format:'%h,%an,%ad,%s' c488e01..origin/master --reverse)
 
 skip_counter=$SKIP
 in_range=false


### PR DESCRIPTION
Fix regression scheduler

When we manually schedule jobs for a newly added test, some jobs are not added due to a wrong end point.