### PR TITLE
Fix time format for Github requests

### DIFF
--- a/bin/common
+++ b/bin/common
@@ -41,12 +41,12 @@ Please check the log file for more details: $LOG_URL/$(basename $LOG)"
 
 measure() {
   args="$@"
-  measure-and-output "dotty-bench-bootstrapped/jmh:run $args -d $PROG_HOME/out -nowarn"
+  measure-and-output "scala3-bench-bootstrapped/jmh:run $args -d $PROG_HOME/out -nowarn"
 }
 
 measure-run() {
   args="$@"
-  measure-and-output "dotty-bench-run/jmh:run $args --"
+  measure-and-output "scala3-bench-run/jmh:run $args --"
 }
 
 prepare() {
@@ -66,7 +66,7 @@ prepare() {
   git submodule update
 
   git clean -xdf
-  run-sbt "dotty-bench-bootstrapped/jmh:compile" 2>&1 | tee -a "$LOG"
+  run-sbt "scala3-bench-bootstrapped/jmh:compile" 2>&1 | tee -a "$LOG"
 
   # for compilation with `dotc`
   run-sbt "dist/pack"  2>&1 | tee -a "$LOG"
@@ -74,7 +74,7 @@ prepare() {
 
 compile() {
   args="$@"
-  run-sbt "dotty-bootstrapped/dotc $args" 2>&1 | tee -a "$LOG"
+  run-sbt "scala3-bootstrapped/scalac $args" 2>&1 | tee -a "$LOG"
 }
 
 set-key() {

--- a/bin/poll
+++ b/bin/poll
@@ -56,7 +56,7 @@ TEMP_FILE="$PROG_HOME/last-message.json"
 ############## Polling
 while true; do
   curl "https://api.github.com/repos/$REPO/issues/comments?since=$LAST_POLL" > "$TEMP_FILE"
-  LAST_POLL=$(date +"%Y-%m-%dT%H:%M:%S%s")
+  LAST_POLL=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
   cat "$TEMP_FILE"
 


### PR DESCRIPTION
Fix time format for Github requests

Fix #579 #580 #582

```json
{
  "message": "The since parameter needs to be in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
  "documentation_url": "https://docs.github.com/rest/reference/issues#list-issue-comments-for-a-repository"
}
```